### PR TITLE
GitHub workflow added to upload *.ipk files during release

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,28 @@
+name: Build app
+
+on:
+  push:
+    branches: [ main ]
+    tags: 
+      - '*'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - run: npm install
+    - run: npm run build
+    - run: npm run package
+    - name: Uploading release assets
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: '*.ipk'


### PR DESCRIPTION
Hello,

I created a simple Github workflow to upload *.ipk asset for the releases.
This can simplify the process of installing applications on TV for less technical users.
With this users won't have to compile the application by themselves - they just need to download the `ipk` file from github and call `ares-install -d ... youtube.leanback.v4_..._all.ipk`.

The workflow itself uses the [@softprops/action-gh-release](https://github.com/softprops/action-gh-release) action, which allows to add assets to the release.
For example:
![image](https://user-images.githubusercontent.com/29204450/145047569-cbdb500c-f783-44fe-9136-e2a39d4cb841.png)

Additionally workflow runs during push and pull request to verify correctness of source code (we make sure that the code compiles).
